### PR TITLE
Add ephemeral reply

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,9 @@
 use Mix.Config
 
-config :slack, api_token: System.get_env("OAUTH_ACCESS_TOKEN")
+config :slack,
+  api_token: System.get_env("OAUTH_ACCESS_TOKEN"),
+  user_token: System.get_env("USER_OAUTH_ACCESS_TOKEN"),
+  slack_url: "https://slack.com/api/"
 
 config :sphinx,
   owner_username: "sphinx",

--- a/lib/sphinx_rtm.ex
+++ b/lib/sphinx_rtm.ex
@@ -25,6 +25,10 @@ defmodule SphinxRtm do
         send_thread_reply(reply, message, slack)
         {:ok, state}
 
+      {:ephemeral, text} ->
+        SlackUtils.send_ephemeral_reply(message.channel, text, message.user)
+        {:ok, state}
+
       :no_reply ->
         {:ok, state}
     end

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -29,7 +29,7 @@ defmodule SphinxRtm.Messages do
             |> Map.put(:text, content)
             |> save_question()
 
-            {:ephemeral, "You're question is saved"}
+            {:ephemeral, "Your question is saved!"}
 
           {:search, content} ->
             content = if content == "", do: text, else: content

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -29,8 +29,7 @@ defmodule SphinxRtm.Messages do
             |> Map.put(:text, content)
             |> save_question()
 
-            # It will change for {:reply, "You're question is saved"} by post_ephemeral
-            :no_reply
+            {:ephemeral, "You're question is saved"}
 
           {:search, content} ->
             content = if content == "", do: text, else: content

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -4,6 +4,14 @@ defmodule SphinxRtm.Messages do
   alias Sphinx.SlackUtils
   alias Sphinx.Answers
 
+  @help """
+  ```
+  @sphinx help Print Sphinx commands \n
+  @sphinx [TEXT] Starts a thread with SphinxBot \n
+  @sphinx [SAVE] [TEXT] It saves the link to the thread without title \n
+  ...
+  ```
+  """
   ## TODO: check if message is a question
   ## if yes then get the keywords and search for old questions
   ## else check if it is related to/ answering the recent question.
@@ -22,7 +30,7 @@ defmodule SphinxRtm.Messages do
 
         case Parser.check_content(text) do
           {:help, _} ->
-            {:reply, help()}
+            {:ephemeral, @help}
 
           {:save, content} ->
             message
@@ -36,7 +44,7 @@ defmodule SphinxRtm.Messages do
 
             case SlackUtils.search(content, message.channel) do
               nil ->
-                {:reply,
+                {:ephemeral,
                  "You asked for \"#{content}\" but I have no answer! Invoke @sphinx [SAVE] [TEXT] to save the question for future use!"}
 
               reply ->
@@ -95,16 +103,5 @@ defmodule SphinxRtm.Messages do
   defp get_thread_permalink(channel_id, ts) do
     permalink(channel_id, ts)
     |> String.replace(~r/[?](.)*/, "")
-  end
-
-  defp help do
-    """
-    ```
-    @sphinx help Print Sphinx commands \n
-    @sphinx [TEXT] Starts a thread with SphinxBot \n
-    @sphinx [SAVE] [TEXT] It saves the link to the thread without title \n
-    ...
-    ```
-    """
   end
 end

--- a/lib/utils/slack_args.ex
+++ b/lib/utils/slack_args.ex
@@ -1,13 +1,18 @@
 defmodule Sphinx.SlackArgs do
+  alias Sphinx.SlackUtils
+
   @spec search_args(map()) :: map()
   def search_args(attrs \\ %{}) do
-    query = Map.get(attrs, :query)
-    channel = Map.get(attrs, :channel)
-    count = Map.get(attrs, :count, 20)
-    highlight = Map.get(attrs, :highlight)
-    page = Map.get(attrs, :page, 1)
-    sort = Map.get(attrs, :sort, "score")
-    sort_dir = Map.get(attrs, :sort_dir, "desc")
+    channel_name =
+      Map.get(attrs, :channel)
+      |> SlackUtils.get_channel_name()
+
+    query = "in:##{channel_name} " <> Map.get(attrs, :query)
+    count = Map.get(attrs, :count, nil)
+    highlight = Map.get(attrs, :highlight, nil)
+    page = Map.get(attrs, :page, nil)
+    sort = Map.get(attrs, :sort, nil)
+    sort_dir = Map.get(attrs, :sort_dir, nil)
     pretty = Map.get(attrs, :pretty, 1)
 
     optional =
@@ -20,7 +25,7 @@ defmodule Sphinx.SlackArgs do
         pretty: pretty
       })
 
-    Map.merge(%{channel: channel, query: query}, optional)
+    Map.merge(optional, %{query: query})
   end
 
   defp clean_fields(params) do

--- a/lib/utils/slack_args.ex
+++ b/lib/utils/slack_args.ex
@@ -25,7 +25,7 @@ defmodule Sphinx.SlackArgs do
         pretty: pretty
       })
 
-    Map.merge(optional, %{query: query})
+    Map.merge(%{query: query}, optional)
   end
 
   defp clean_fields(params) do

--- a/lib/utils/slack_utils.ex
+++ b/lib/utils/slack_utils.ex
@@ -41,6 +41,11 @@ defmodule Sphinx.SlackUtils do
     end
   end
 
+  @spec send_ephemeral_reply(String.t(), String.t(), String.t()) :: map()
+  def send_ephemeral_reply(channel, text, user) do
+    Chat.post_ephemeral(channel, text, user)
+  end
+
   defp build_response(matches, _text, channel) do
     blocks =
       Enum.filter(matches, &match?(%{"channel" => %{"id" => ^channel}}, &1))

--- a/lib/utils/slack_utils.ex
+++ b/lib/utils/slack_utils.ex
@@ -70,6 +70,7 @@ defmodule Sphinx.SlackUtils do
     end
   end
 
+  defp build_text("", _, []), do: nil
   defp build_text(response, _, []), do: response
 
   defp build_text(response, count, [block | blocks]) do

--- a/lib/utils/slack_utils.ex
+++ b/lib/utils/slack_utils.ex
@@ -1,5 +1,6 @@
 defmodule Sphinx.SlackUtils do
   use Slack
+  alias Slack.Web.Channels
   alias Slack.Web.Chat
   alias Slack.Web.Users
   alias Slack.Web.Reactions
@@ -7,6 +8,12 @@ defmodule Sphinx.SlackUtils do
 
   @user_token Application.get_env(:slack, :user_token)
   @slack_url Application.get_env(:slack, :slack_url)
+
+  @spec get_channel_name(String.t()) :: String.t()
+  def get_channel_name(channel_id) do
+    Channels.info(channel_id)
+    |> get_in(["channel", "name"])
+  end
 
   @spec get_permalink(String.t(), String.t()) :: String.t()
   def get_permalink(channel_id, ts) do

--- a/lib/utils/slack_utils.ex
+++ b/lib/utils/slack_utils.ex
@@ -36,7 +36,7 @@ defmodule Sphinx.SlackUtils do
 
   defp build_response(matches, text, channel) do
     blocks =
-      Enum.filter(matches, &match?(%{"channel" => %{"id" => channel}, "text" => text}, &1))
+      Enum.filter(matches, &match?(%{"channel" => %{"id" => ^channel}, "text" => text}, &1))
       |> Enum.sort_by(&get_upvote_count(&1), &>=/2)
 
     build_text("", 1, blocks)

--- a/lib/utils/slack_utils.ex
+++ b/lib/utils/slack_utils.ex
@@ -41,9 +41,9 @@ defmodule Sphinx.SlackUtils do
     end
   end
 
-  defp build_response(matches, text, channel) do
+  defp build_response(matches, _text, channel) do
     blocks =
-      Enum.filter(matches, &match?(%{"channel" => %{"id" => ^channel}, "text" => text}, &1))
+      Enum.filter(matches, &match?(%{"channel" => %{"id" => ^channel}}, &1))
       |> Enum.sort_by(&get_upvote_count(&1), &>=/2)
 
     build_text("", 1, blocks)

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -103,9 +103,9 @@ defmodule SphinxRtm.MessagesTest do
         {Slack.Web.Chat, [], [get_permalink: fn "XYZ", "123.456" -> @question_permalink end]}
       ]) do
         question = %{@question | text: "<@SPX> 5eb63bbbe01eeed093cb22bb8f5acdc3"}
-        assert {:reply, response} = Messages.process(question)
+        assert {:ephemeral, response} = Messages.process(question)
 
-        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\", you might find these helpful: \n " =~
+        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\" but I have no answer! Invoke @sphinx [SAVE] [TEXT] to save the question for future use!" =~
                  response
       end
     end

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -105,7 +105,7 @@ defmodule SphinxRtm.MessagesTest do
         question = %{@question | text: "<@SPX> 5eb63bbbe01eeed093cb22bb8f5acdc3"}
         assert {:reply, response} = Messages.process(question)
 
-        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\" but I have no answer! Invoke @sphinx [SAVE] [TEXT] to save the question for future use!" =~
+        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\", you might find these helpful: \n " =~
                  response
       end
     end


### PR DESCRIPTION
When calling sphinx to save a question, it sends a confirmation reply only visible to the user who invoked him.